### PR TITLE
Adding a trailing semicolon to bim1a_axisymmetric_advection_upwind.m

### DIFF
--- a/inst/bim1a_axisymmetric_advection_upwind.m
+++ b/inst/bim1a_axisymmetric_advection_upwind.m
@@ -56,7 +56,7 @@ function A = bim1a_axisymmetric_advection_upwind (x, beta)
   nnodes = length(x);
   nelem  = nnodes-1;
 
-  cm    = reshape((x(1:end-1)+x(2:end))/2,[],1)
+  cm    = reshape((x(1:end-1)+x(2:end))/2,[],1);
   
   if (length(beta) == 1)
     vk = 0;#zeros(nelem,1);


### PR DESCRIPTION
Adding a trailing semicolon to  bim1a_axisymmetric_advection_upwind.m (octave bug #44883
https://savannah.gnu.org/bugs/?44883)