### PR TITLE
Update index.html Fix to avoid overlap of package logo and title

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -84,7 +84,7 @@
         <div class="card-header card-header-mod">
           <div class="row d-flex flex-wrap align-items-center">
             <div class="col-sm-3 col-md-2 mb-2 mb-sm-0">
-              <img src="assets/bim.png" class="d-block m-auto" alt="bim">
+               <img src="assets/bim.png" class="img-fluid" alt="bim" style="max-height: 180px;">
             </div>
             <div class="col-sm-9 col-md-10">
               <h3 class="d-inline-block mr-2">bim</h3>


### PR DESCRIPTION
The html display problem caused by page scaling has been solved by modifying the pkg-octave-doc template.
https://github.com/gnu-octave/pkg-octave-doc/pull/17#issue-3127313701
